### PR TITLE
Fixed a typo 

### DIFF
--- a/Chapter 6 : More Complex Repetitions.md
+++ b/Chapter 6 : More Complex Repetitions.md
@@ -259,7 +259,7 @@
 		{
 			if (num < i*i*i)
 				break;
-		or (j = i + 1; j < num; j++)
+		for (j = i + 1; j < num; j++)
 			{
 				if (num < j*j*j)
 					break;


### PR DESCRIPTION
#### Description
The solution for the question **(l)** in **Exercise[C]** of **chapter 6 : More Complex Repetitions** has a small mistake in line 13. The **'f'** in the `for` is missing and `or` is present which is leading to an error while trying to run the program.


**This pull request fixes the issue** 
- #86 

In line 13 of the code in **(l)** of **Exercise[C]** in **Chapter 6 : More Complex Repetitions** I made the following changes
```diff
- or (j = i + 1; j < num; j++)

+ for (j = i + 1; j < num; j++)